### PR TITLE
Fix bug causing directions not to reset

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -109,6 +109,7 @@ const displaySelectedRecipe = (recipe) => {
   recipeImage.innerHTML = `<img src="${recipe.image}">`;
   recipeName.innerText = `${recipe.name}`
   recipeIngredients.innerHTML = "";
+  recipeDirections.innerHTML = "";
   recipe.getIngredientNames(activeRecipeRepo.ingredients).forEach(ingredient => {
     recipeIngredients.innerHTML += `<p>${ingredient}<p>`;
   });


### PR DESCRIPTION
#### What does this PR do?
Fixes bug causing directions not to reset: if you click on two recipes, both directions would show up
#### Where should the reviewer start?
scripts.js
#### How should this be manually tested?
click on multiple recipes, check directions list

  
